### PR TITLE
version: bump to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4083,9 +4083,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-minecraft",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-minecraft",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-minecraft",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "React hooks and components for Minecraft resource pack development",
   "keywords": [
     "minecraft",

--- a/src/components/texture.tsx
+++ b/src/components/texture.tsx
@@ -5,53 +5,126 @@ import type { MCMeta } from "../types.js";
 
 export declare namespace Texture {
 	interface props {
+		/**
+		 * Source URL of the texture (any url that can be used in an img tag)
+		 */
 		src: HTMLImageElement['src'];
+		/**
+		 * The alt text for the image, unused when @see animation is provided
+		 */
 		alt?: string;
-		style?: React.CSSProperties;
-		className?: string;
-		
-		size?: React.CSSProperties['width'];
 
-		mcmeta?: { 
-			animation?: MCMeta.Animation;
+		/**
+		 * The size of the texture in the parent container
+		 * @default '100%'
+		 */
+		size?: React.CSSProperties['width'];
+		
+		/**
+		 * The animation data to use for the animation
+		 */
+		animation?: {
+			/**
+			 * MCMeta data to use for the animation
+			 * @see https://minecraft.wiki/w/Resource_pack#Animation
+			 */
+			mcmeta: { animation: MCMeta.Animation };
+			/**
+			 * Tells the hook to center the image in the canvas
+			 * Used for fluids and other textures when it needs to seamlessly rotates (in-game) 
+			 * without cutting off corners or extending beyond the texture's boundaries.
+			 * @default false
+			 */
 			tiled?: boolean;
+			/**
+			 * Tells if the animation should play or not, if a number is provided, the animation will pause on that tick
+			 * @default false
+			 */
+			paused?: boolean | number;
 		};
+
+		/**
+		 * The background color or image url to use for the texture
+		 */
 		background?: {
+			/**
+			 * CSS color to use as the background
+			 */
 			color?: React.CSSProperties['color'];
+			/**
+			 * URL of the image to use as the background, used as `url(${background.url})` in the style
+			 */
 			url?: HTMLImageElement['src'];
 		};
+
+		style?: React.CSSProperties;
+		className?: string;
 	}
 
 	export namespace Image {
 		interface props extends React.ImgHTMLAttributes<HTMLImageElement> {
+			/**
+			 * Source URL of the image (any url that can be used in an img tag)
+			 */
 			src: HTMLImageElement['src'];
+			/**
+			 * The alt text for the image
+			 */
 			alt?: string;
 		}
 	}
 
 	export namespace Canvas {
 		interface props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
-			src: HTMLImageElement['src'];
-			mcmeta: Texture.props['mcmeta'];
+			/**
+			 * Source URL of the image to animate (any url that can be used in an img tag)
+			 */
+			src: Texture.props['src'];
+			/**
+			 * The MCMETA data to use for the animation
+			 */
+			mcmeta: { animation: MCMeta.Animation };
+			/**
+			 * Tells if the animation should play or not, if a number is provided, the animation will pause on that tick
+			 * @default false
+			 */
+			isPaused?: boolean | number;
+			/**
+			 * Tells the hook to center the image in the canvas
+			 * Used for fluids and other textures when it needs to seamlessly rotates (in-game) 
+			 * without cutting off corners or extending beyond the texture's boundaries.
+			 * @default false
+			 */
+			isTiled?: boolean;
 		}
 	}
 
 	export namespace Background {
 		interface props extends React.HTMLAttributes<HTMLDivElement> {
+			/**
+			 * The size of the texture in the parent container
+			 * @default '100%'
+			 */
 			size?: Texture.props['size'];
+			/**
+			 * The background color or image url to use for the texture
+			 */
 			background: Texture.props['background'];
-			children?: React.ReactNode;
+			/**
+			 * The children to render inside the background, usually the @see Texture.Canvas or @see Texture.Image
+			 */
+			children: React.ReactNode;
 		}
 	}
 }
 
-export function Texture({ src, size, background, mcmeta, ...props }: Texture.props) {
+export function Texture({ src, size, background, animation, ...props }: Texture.props) {
 	return (
 		<Texture.Background size={size} background={background} {...props}>
-			{mcmeta && (
-				<Texture.Canvas src={src} mcmeta={mcmeta} {...props} />
+			{animation && (
+				<Texture.Canvas src={src} mcmeta={animation.mcmeta} isPaused={animation.paused} isTiled={animation.tiled} {...props} />
 			)}
-			{!mcmeta && (
+			{!animation && (
 				<Texture.Image src={src} {...props} />
 			)}
 		</Texture.Background>
@@ -91,8 +164,8 @@ Texture.Image = ({ src, alt, style, ...props }: Texture.Image.props) => {
 	return <img src={src} alt={alt} style={_style} {...props} />;
 }
 
-Texture.Canvas = ({ src, mcmeta, ...props }: Texture.Canvas.props) => {
-	const { canvasRef } = useAnimation({ src, mcmeta, isTiled: mcmeta?.tiled });
+Texture.Canvas = ({ src, mcmeta, isPaused, isTiled, ...props }: Texture.Canvas.props) => {
+	const { canvasRef } = useAnimation({ src, mcmeta, isPaused, isTiled });
 	return (
 		<canvas 
 			ref={canvasRef}

--- a/src/components/texture.tsx
+++ b/src/components/texture.tsx
@@ -1,6 +1,6 @@
-import React, { isValidElement } from "react";
-import { useAnimation } from "../hooks/useAnimation.js"
+import React from "react";
 
+import { useAnimation } from "../hooks/useAnimation.js"
 import type { MCMeta } from "../types.js";
 
 export declare namespace Texture {
@@ -32,7 +32,7 @@ export declare namespace Texture {
 	export namespace Canvas {
 		interface props extends React.CanvasHTMLAttributes<HTMLCanvasElement> {
 			src: HTMLImageElement['src'];
-			mcmeta?: Texture.props['mcmeta'];
+			mcmeta: Texture.props['mcmeta'];
 		}
 	}
 
@@ -64,6 +64,7 @@ Texture.Background = ({ size, children, background, style, ...props }: Texture.B
 		backgroundSize: 'cover',
 		imageRendering: 'pixelated',
 
+		minHeight: size ?? '100%',
 		height: size ?? '100%',
 		width: size ?? '100%',
 
@@ -91,9 +92,7 @@ Texture.Image = ({ src, alt, style, ...props }: Texture.Image.props) => {
 }
 
 Texture.Canvas = ({ src, mcmeta, ...props }: Texture.Canvas.props) => {
-	const { canvasRef, isValid } = useAnimation({ src, mcmeta, isTiled: mcmeta?.tiled });
-	if (!isValid) return Texture.Image({ src });
-
+	const { canvasRef } = useAnimation({ src, mcmeta, isTiled: mcmeta?.tiled });
 	return (
 		<canvas 
 			ref={canvasRef}

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -17,12 +17,14 @@ export declare namespace useAnimation {
 		 * Tells the hook to center the image in the canvas
 		 * Used for fluids and other textures when it needs to seamlessly rotates (in-game) 
 		 * without cutting off corners or extending beyond the texture's boundaries.
+		 * @default false
 		 */
 		isTiled?: boolean;
 		/**
-		 * Tells if the animation should play or not
+		 * Tells if the animation should play or not, if a number is provided, the animation will pause on that tick
+		 * @default false
 		 */
-		isPaused?: boolean;
+		isPaused?: boolean | number;
 	}
 
 	interface output {
@@ -123,12 +125,19 @@ export function useAnimation({ src, mcmeta, isTiled, isPaused }: useAnimation.pa
 	// Main loop to play the animation
 	useEffect(() => {
 		if (Object.keys(frames).length === 0) return;
-		if (isPaused) return;
 
 		setTimeout(() => {
-			let next = currentTick + 1;
-			if (frames[next] === undefined) next = 1;
-			setTick(next);
+			if (!isPaused && isPaused !== 0) {
+				let next = currentTick + 1;
+				if (frames[next] === undefined) next = 1;
+				setTick(next);
+			}
+			else {
+				const tickToPause = typeof isPaused === 'number' 
+					? ((isPaused - 1) % Object.keys(frames).length) + 1 // 1-indexed
+					: currentTick;
+				setTick(tickToPause);
+			}
 		}, 1000 / 20); // 20 ticks per second (50ms per tick)
 
 	}, [frames, currentTick, isPaused]);

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -32,6 +32,10 @@ export declare namespace useAnimation {
 		 * A reference to the canvas element used for the animation
 		 */
 		canvasRef: React.RefObject<HTMLCanvasElement>;
+		/**
+		 * Determined sprites from the MCMETA data
+		 */
+		sprites: MCMeta.AnimationFrame[];
 	}
 }
 
@@ -46,6 +50,7 @@ export function useAnimation({ src, mcmeta, isTiled, isPaused }: useAnimation.pa
 	const [image, setImage] = useState<HTMLImageElement | null>(null);
 	const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
 
+	const [sprites, setSprites] = useState<MCMeta.AnimationFrame[]>([]);
 	const [frames, setFrames] = useState<Record<number, [MCMeta.AnimationFrame, number][]>>({});
 	const [currentTick, setTick] = useState(1);
 
@@ -120,6 +125,7 @@ export function useAnimation({ src, mcmeta, isTiled, isPaused }: useAnimation.pa
 		})
 
 		setFrames(framesToPlay);
+		setSprites(animationFrames);
 	}, [image, isTiled, mcmeta]);
 
 	// Main loop to play the animation
@@ -183,5 +189,8 @@ export function useAnimation({ src, mcmeta, isTiled, isPaused }: useAnimation.pa
 		}
 	}, [currentTick, canvas, image, canvasRef, frames]);
 
-	return { canvasRef };
+	return { 
+		canvasRef,
+		sprites,
+	};
 }

--- a/src/hooks/useAnimation.tsx
+++ b/src/hooks/useAnimation.tsx
@@ -19,6 +19,10 @@ export declare namespace useAnimation {
 		 * without cutting off corners or extending beyond the texture's boundaries.
 		 */
 		isTiled?: boolean;
+		/**
+		 * Tells if the animation should play or not
+		 */
+		isPaused?: boolean;
 	}
 
 	interface output {
@@ -26,59 +30,130 @@ export declare namespace useAnimation {
 		 * A reference to the canvas element used for the animation
 		 */
 		canvasRef: React.RefObject<HTMLCanvasElement>;
-		/**
-		 * A boolean indicating if the animation is valid and is displayed
-		 */
-		isValid: boolean;
 	}
 }
 
 /**
  * A hook to animate a texture using the given MCMETA data
- * @author Even Torset &lt;https://github.com/EvenTorset&gt; for the original MCMETA to canvas code
- *
  * @returns A ref to the canvas element and a boolean indicating if the MCMETA data is valid
  */
-export function useAnimation({ src, mcmeta, isTiled }: useAnimation.params): useAnimation.output {
+export function useAnimation({ src, mcmeta, isTiled, isPaused }: useAnimation.params): useAnimation.output {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
-	const animationInterval = useRef<NodeJS.Timeout>();
+	const tickingRef = useRef<NodeJS.Timeout>();
 
-	const [isValid, setValid] = useState(false);
+	const [image, setImage] = useState<HTMLImageElement | null>(null);
+	const [canvas, setCanvas] = useState<HTMLCanvasElement | null>(null);
 
+	const [frames, setFrames] = useState<Record<number, [MCMeta.AnimationFrame, number][]>>({});
+	const [currentTick, setTick] = useState(1);
+
+	// Update the image when the src changes
 	useEffect(() => {
-		// Clear the previous interval if it exists
-		// >> avoid cumulative intervals when the component re-renders
-		if (animationInterval.current) {
-			clearInterval(animationInterval.current);
-			animationInterval.current = undefined;
+		setCanvas(canvasRef.current);
+
+		const img = new Image();
+		img.src = src;
+
+		img.onload = () => {
+			setImage(img);
+			tickingRef.current = setInterval(() => {}, 1000 / 20);
+		};
+
+		img.onerror = () => {
+			setImage(null);
+			if (tickingRef.current) {
+				clearInterval(tickingRef.current);
+				tickingRef.current = undefined;
+			}
 		}
 
-		// Short return if the mcmeta is not valid or not present
-		if (!mcmeta) return setValid(false);
+	}, [src]);
 
-		setValid(true);
+	// Update the frames when the image or mcmeta changes
+	useEffect(() => {
+		if (!image || !mcmeta) return;
+		const animation = mcmeta.animation ?? {};
 
-		const image = new Image();
-		image.src = src;
+		// convert all frames to an array of objects with index and time
+		const animationFrames: MCMeta.AnimationFrame[] = [];
 
-		const tick = Math.max(mcmeta?.animation?.frametime || 1, 1);
-		const frames: MCMeta.AnimationFrame[] = [];
+		if (animation.frames) {
+			for (const frame of animation.frames) {
+				switch (typeof frame) {
+					// already in the correct format
+					case 'object':
+						animationFrames.push({ index: frame.index, time: Math.max(frame.time, 1) });
+						break;
+					// map the frame to the correct format
+					case 'number':
+						animationFrames.push({ index: frame, time: animation.frametime ?? 1 });
+						break;
+				}
+			}
+		}
+		// no frames specified, so we assume the image is a sprite sheet
+		else {
+			const framesCount = isTiled ? (image.height / 2) / (image.width / 2) : image.height / image.width;
+			for (let fi = 0; fi < framesCount; fi++) {
+				animationFrames.push({ index: fi, time: animation.frametime ?? 1 });
+			}
+		}
 
-		let interval: number;
+		// determines what frames (including interpolated ones) to play on each tick
+		// => { tick: [frame, alpha][] } (where the first frame has always an alpha of 1 and the second one is interpolated)
+		const framesToPlay: Record<number, [MCMeta.AnimationFrame, number][]> = {};
 
-		const canvas = canvasRef.current;
-		if (!canvas) return;
+		let ticks = 1;
+		animationFrames.forEach((frame, index) => {
+			for (let t = 1; t <= frame.time; t++) {
+				framesToPlay[ticks] = [[frame, 1]];
+				
+				if (animation.interpolate) {
+					const nextFrame = animationFrames[index + 1] ?? animationFrames[0]!;
+					framesToPlay[ticks]!.push([nextFrame, t / nextFrame.time]);
+				}
 
-		const context = canvas.getContext('2d');
-		if (!context) return;
+				ticks++;
+			}
+		})
 
-		const draw = (frame = 0, ticks = 0) => {
-			const padding = isTiled ? image.width / 4 : 0;
-			const width = isTiled ? image.width / 2 : image.width;
+		setFrames(framesToPlay);
+	}, [image, isTiled, mcmeta]);
 
-			context.clearRect(0, 0, width, width);
-			context.globalAlpha = 1;
-			context.imageSmoothingEnabled = false;
+	// Main loop to play the animation
+	useEffect(() => {
+		if (Object.keys(frames).length === 0) return;
+		if (isPaused) return;
+
+		setTimeout(() => {
+			let next = currentTick + 1;
+			if (frames[next] === undefined) next = 1;
+			setTick(next);
+		}, 1000 / 20); // 20 ticks per second (50ms per tick)
+
+	}, [frames, currentTick, isPaused]);
+
+	useEffect(() => {
+		if (Object.keys(frames).length === 0) return;
+		const framesToDraw = frames[currentTick];
+
+		const context = canvas?.getContext('2d');
+		if (!canvas || !context || !image || !framesToDraw) return;
+
+		canvas.style.width = '100%';
+		canvas.width = canvas.offsetWidth;
+		canvas.height = canvas.offsetWidth;
+
+		const padding = isTiled ? image.width / 4 : 0;
+		const width = isTiled ? image.width / 2 : image.width;
+
+		context.clearRect(0, 0, width, width);
+		context.globalAlpha = 1;
+		context.imageSmoothingEnabled = false;
+
+		for (const frame of framesToDraw) {
+			const [data, alpha] = frame;
+			context.globalAlpha = alpha;
 
 			context.drawImage(
 				// source image
@@ -86,7 +161,7 @@ export function useAnimation({ src, mcmeta, isTiled }: useAnimation.params): use
 
 				// position on source image
 				// top left, top right
-				padding, padding + (width * frames[frame]?.index!) * (isTiled ? 2 : 1),
+				padding, padding + (width * data.index) * (isTiled ? 2 : 1),
 				// width, height of the source image
 				width, width,
 
@@ -96,91 +171,8 @@ export function useAnimation({ src, mcmeta, isTiled }: useAnimation.params): use
 				// width, height
 				canvas.width, canvas.width
 			);
+		}
+	}, [currentTick, canvas, image, canvasRef, frames]);
 
-			// Partially draw the next frame if interpolation is enabled
-			if (mcmeta?.animation?.interpolate) {
-				context.globalAlpha = ticks / (frames[frame]?.time ?? 1);
-				context.drawImage(
-					image,
-
-					padding, padding + (width * frames[(frame + 1) % frames.length]?.index!) * (isTiled ? 2 : 1),
-					width, width,
-
-					0, 0,
-					canvas.width, canvas.height
-				);
-			}
-		};
-
-		image.onload = () => {
-			if (mcmeta?.animation?.frames && mcmeta?.animation.frames.length > 0) {
-				interval =
-					mcmeta?.animation.interpolate ||
-						mcmeta?.animation.frames.find((e) => typeof e === 'object' && e.time % tick !== 0)
-						? 1
-						: tick;
-
-				for (let e = 0; e < mcmeta?.animation.frames.length; e++) {
-					const a = mcmeta?.animation.frames[e]!;
-
-					if (typeof a === 'object')
-						frames.push({
-							index: a.index,
-							time: Math.max(a.time, 1) / interval,
-						});
-					else
-						frames.push({
-							index: a,
-							time: tick / interval,
-						});
-				}
-			} else {
-				interval = mcmeta?.animation?.interpolate ? 1 : tick;
-				const framesCount = isTiled 
-					? (image.height / 2) / (image.width / 2)
-					: image.height / image.width;
-
-				for (let fi = 0; fi < framesCount; fi++) {
-					frames.push({ index: fi, time: tick / interval });
-				}
-			}
-
-			let ticks = 0;
-			let currentFrame = 0;
-
-			const update = () => {
-				ticks++;
-
-				// update canvas size each frame to match the container size
-				// >> this is required if the canvas is first hidden and then shown
-				canvas.style.width = '100%';
-				canvas.width = canvas.offsetWidth;
-				canvas.height = canvas.offsetWidth;
-
-				if (frames[currentFrame]!.time <= ticks) {
-					ticks = 0;
-					currentFrame++;
-					if (currentFrame >= frames.length) currentFrame = 0;
-					draw(currentFrame);
-				} else if (mcmeta?.animation?.interpolate) draw(currentFrame, ticks);
-			};
-
-			if (!animationInterval.current) {
-				update(); // initial draw before starting interval
-				animationInterval.current = setInterval(update, interval * 60);
-			}
-		};
-
-		image.onerror = () => {
-			canvas.remove();
-			setValid(false);
-		};
-
-	}, [
-		src,
-		mcmeta,
-		isValid, // re-run if the mcmeta validity changes
-	]);
-
-	return { canvasRef, isValid };
+	return { canvasRef };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components/index.js';
 export * from './hooks/index.js';
+export * from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 export declare namespace MCMeta {
 	/**
 	 * @see https://minecraft.wiki/w/Resource_pack#Animation
@@ -42,4 +41,40 @@ export declare namespace MCMeta {
 		 */
 		time: number;
 	}
+
+	interface Texture {
+		blur?: boolean;
+		clamp?: boolean;
+		mipmaps?: number[];
+	}
+
+	interface GUI {
+		scaling?: {
+			type?: 'stretch' | 'tile' | 'nine_slice';
+			width?: number;
+			height?: number;
+			border?: number | GUIPosition;
+		}
+	}
+
+	interface GUIPosition {
+		left?: number;
+		top?: number;
+		right?: number;
+		bottom?: number;
+	}
+
+	interface Villager {
+		hat?: 'full' | 'partial';
+	}
+}
+
+/**
+ * Everything that can be stored in a `.png.mcmeta` file
+ */
+export interface TextureMCMeta {
+	animation?: MCMeta.Animation;
+	texture?: MCMeta.Texture;
+	gui?: MCMeta.GUI;
+	villager?: MCMeta.Villager;
 }

--- a/tests/useAnimation.test.tsx
+++ b/tests/useAnimation.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { render, renderHook } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
@@ -15,11 +15,9 @@ describe('useAnimation', () => {
 			animation: {},
 		};
 
-		const { canvasRef, isValid } = renderHookUnpacker(renderHook(() => useAnimation({ src, mcmeta })));
+		const { canvasRef } = renderHookUnpacker(renderHook(() => useAnimation({ src, mcmeta })));
 
 		render(<canvas ref={canvasRef} />);
-
-		expect(isValid).toBe(true);
 		expect(canvasRef.current).toBeInstanceOf(HTMLCanvasElement);
 	});
 
@@ -27,11 +25,9 @@ describe('useAnimation', () => {
 		const src = `${url}/campfire_fire.png`;
 		const mcmeta = undefined;
 
-		const { canvasRef, isValid } = renderHookUnpacker(renderHook(() => useAnimation({ src, mcmeta })));
+		const { canvasRef } = renderHookUnpacker(renderHook(() => useAnimation({ src, mcmeta })));
 
 		render(<canvas ref={canvasRef} />);
-
-		expect(isValid).toBe(false);
 		expect(canvasRef.current).toBeInstanceOf(HTMLCanvasElement);
 	});
 });


### PR DESCRIPTION
## Fixes

- Fix flickering on animations
- Update dev-deps micromatch to latest version to fix npm warning

## Rework

- Completly rework the `useAnimation` hook to be split into multiple `useEffect` calls and update only what's needed
  - Exposes the "parsed" frames in the hook result
  - Remove `isValid` as it's not necessary anymore